### PR TITLE
README, FAQ: fix broken links

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -57,6 +57,6 @@ but CGN networks are wildly popular.
 
 As a totally new address range, making class-e in particular globally
 routable makes it more possible to address other long-standing bugs in
-IPv4 implementations like [zeroth networks](ZEROTH.md), attempt to make
+IPv4 implementations like [zeroth networks](LOWEST.md), attempt to make
 more protocols available through NAT (such as udp-lite, sctp), and so on.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fixing the odd nooks and crannies still mildly broken in IPv4, by:
 
 - Making class-e (240/4), 0/8, 127/8, 224/4 more usable
 - Adding 419 million new IPs to the world
-- Fixing [zeroth networking](/ZEROTH.md)
+- Fixing [zeroth networking](LOWEST.md)
 - Improving interoperability with multiple protocols and tunnelling technologies
 - Supplying tested patches and tools that address these problems
 
@@ -13,9 +13,10 @@ Fixing the odd nooks and crannies still mildly broken in IPv4, by:
 - [OVERVIEW](OVERVIEW.md)
 - [FAQ](FAQ.md)
 - [ZERO](ZERO.md)
-- [ZEROTH](ZEROTH.md)
+- [LOWEST](LOWEST.md)
 - [127.0.0.0/16](127.md)
 - [240/4](CLASSE.md)
 - [MULTICAST](MULTICAST.md)
-- [PATCHES DIR](patches)
+- [MERGED-PATCHES DIR](merged-patches)
+- [PENDING-PATCHES DIR](pending-patches)
 - [PATCHES](PATCHES.md)


### PR DESCRIPTION
Just link fixes to a couple of the top-level markdown files:
- ZEROTH to LOWEST (34ca6d7)
- patches to {merged,pending}-patches (96b1f4f)